### PR TITLE
de-parameterize the workflow bucket

### DIFF
--- a/formation.json
+++ b/formation.json
@@ -5,10 +5,6 @@
       "Default": "console-private",
       "Description": "",
       "Type": "String"
-    },
-    "WorkflowBucket": {
-      "Description": "S3 bucket used as an object store for Workflows",
-      "Type": "String"
     }
   },
   "Outputs": {
@@ -19,6 +15,11 @@
     },
     "DynamoDBSecretAccessKey": {
       "Value": { "Fn::GetAtt": [ "ConsolePrivateDynamoDBAccess", "SecretAccessKey" ] }
+    },
+    "WorkflowObjectStore": {
+      "Value": {
+        "Ref": "ConsolePrivateWorkflowBucket"
+      }
     }
   },
   "Resources": {
@@ -422,10 +423,7 @@
       }
     },
     "ConsolePrivateWorkflowBucket":{
-      "Type" : "AWS::S3::Bucket",
-      "Properties" : {
-        "BucketName" : {"Ref": "WorkflowBucket"}
-      }
+      "Type" : "AWS::S3::Bucket"
     }
   }
 }


### PR DESCRIPTION
This removes the need to set a parameter for the Workflows bucket and adds the generated bucket name as an Output, to make it easier to fetch.