### PR TITLE
Console management role for acct migration and restore tasks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ web:
     - 80:5000
     - 443:443
   labels:
+    - "convox.cron.backup=0 * * * ? backup"
     - "convox.port.443.protocol=tls"
     - "convox.port.443.secure=true"
     - "convox.port.443.proxy=true"

--- a/formation.json
+++ b/formation.json
@@ -122,9 +122,9 @@
                   ]
                 }
               }, {
-                "Effect": "Allow",
-                "Action": [
-                  "dynamodb:ListTables",
+              "Effect": "Allow",
+              "Action": [
+                "dynamodb:ListTables"
                 ],
                 "Resource": "*"
               }, {
@@ -133,13 +133,15 @@
               "Resource" : "*"
               }, {
               "Action": "s3:*",
-              "Fn::Join": [
-                "",
-                [
-                  "arn:aws:s3:::",
-                  {"Ref": "ConsolePrivateWorkflowBucket"}
+              "Resource": [{
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {"Ref": "ConsolePrivateWorkflowBucket"}
+                  ]
                 ]
-              ],
+              }, {
               "Fn::Join": [
                 "",
                 [
@@ -147,18 +149,20 @@
                   {"Ref": "ConsolePrivateWorkflowBucket"},
                   "/*"
                 ]
+              ]
+              }
               ],
               "Effect": "Allow"
               }, {
               "Action": "s3:*",
-              "Resource": [
+              "Resource": [{
                 "Fn::Join": [
                   "",
                   [
                     "arn:aws:s3:::",
                     {"Ref": "ConsolePrivateAuditLogBucket"}
                   ]
-                ],
+                ]}, {
                 "Fn::Join": [
                   "",
                   [
@@ -167,18 +171,19 @@
                     "/*"
                   ]
                 ]
+                }
               ],
               "Effect": "Allow"
               }, {
               "Action": "s3:*",
               "Resource": [
-                "Fn::Join": [
+                {"Fn::Join": [
                   "",
                   [
                     "arn:aws:s3:::",
                     {"Ref": "ConsolePrivateBackupBucket"}
                   ]
-                ],
+                ]}, {
                 "Fn::Join": [
                   "",
                   [
@@ -187,6 +192,7 @@
                     "/*"
                   ]
                 ]
+                }
               ],
               "Effect": "Allow"
               }
@@ -218,8 +224,8 @@
                   "Action" : [
                     "sts:AssumeRole",
                     "iam:GetUser"
-                ],
-                "Resource" : "*"
+                  ],
+                  "Resource" : "*"
                 }
               ]
             }
@@ -238,7 +244,7 @@
     "ConsolePrivateManagementRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
-        "RoleName":
+        "RoleName" : {"Fn::Join" : ["", [{"Ref": "TablePrefix"}, "-management-role" ]]},
         "AssumeRolePolicyDocument": {
           "Version" : "2012-10-17",
           "Statement": [ {
@@ -250,7 +256,15 @@
           } ]
         },
         "Path": "/",
-        "Policies": []
+        "Policies": [{
+          "Effect" : "Allow",
+          "Action" : "s3:*",
+          "Resource" : "*"
+        }, {
+          "Effect" : "Allow",
+          "Action" : "dynamodb:*",
+          "Resource" : "*"
+        }]
       }
     },
     "ConsolePrivateUsersDynamoDBTable" : {
@@ -662,7 +676,7 @@
           "Statement":[{
             "Sid": "Allow administration of the key",
             "Effect": "Allow",
-            "Principal": { "AWS": { "Fn::Join": ["", ["arn:aws:iam::", { "Ref" : "AWS::AccountId" }, ":root"]] } },
+            "Principal": { "Ref": "ConsolePrivateManagementRole" },
             "Action": [
               "kms:Create*",
               "kms:Describe*",

--- a/formation.json
+++ b/formation.json
@@ -247,12 +247,11 @@
         "RoleName" : {"Fn::Join" : ["", [{"Ref": "TablePrefix"}, "-management-role" ]]},
         "AssumeRolePolicyDocument": {
           "Version" : "2012-10-17",
-          "Statement": [ {
+          "Statement": [{
             "Effect": "Allow",
             "Principal": {
               "Service": [ "ec2.amazonaws.com" ]
-            },
-            "Action": [ "sts:AssumeRole" ]
+            }
           }]
         },
         "Path": "/",

--- a/formation.json
+++ b/formation.json
@@ -253,7 +253,7 @@
               "Service": [ "ec2.amazonaws.com" ]
             },
             "Action": [ "sts:AssumeRole" ]
-          } ]
+          }]
         },
         "Path": "/",
         "Policies": [{

--- a/formation.json
+++ b/formation.json
@@ -568,7 +568,9 @@
               "kms:Get*",
               "kms:Delete*",
               "kms:ScheduleKeyDeletion",
-              "kms:CancelKeyDeletion"
+              "kms:CancelKeyDeletion",
+              "kms:Decrypt",
+              "kms:DescribeKey"
             ],
             "Resource": "*"
           },{

--- a/formation.json
+++ b/formation.json
@@ -246,23 +246,22 @@
       "Properties": {
         "RoleName" : {"Fn::Join" : ["", [{"Ref": "TablePrefix"}, "-management-role" ]]},
         "AssumeRolePolicyDocument": {
-          "Version" : "2012-10-17",
           "Statement": [{
             "Effect": "Allow",
-            "Principal": {
-              "Service": [ "ec2.amazonaws.com" ]
-            }
+            "Principal": { "AWS": {"Ref": "AWS::AccountId" }},
+            "Action": ["sts:AssumeRole"]
           }]
         },
         "Path": "/",
         "Policies": [{
-          "Effect" : "Allow",
-          "Action" : "s3:*",
-          "Resource" : "*"
-        }, {
-          "Effect" : "Allow",
-          "Action" : "dynamodb:*",
-          "Resource" : "*"
+          "PolicyName": "ConsoleManagementS3Access",
+          "PolicyDocument": {
+            "Statement": [{
+              "Effect" : "Allow",
+              "Action" : ["s3:*", "dynamodb:*"],
+              "Resource" : "*"
+            }]
+          }
         }]
       }
     },
@@ -279,16 +278,16 @@
         ],
         "KeySchema" : [{ "AttributeName" : "id", "KeyType" : "HASH" }],
         "ProvisionedThroughput" : { "ReadCapacityUnits" : "1", "WriteCapacityUnits" : "1" },
-        "GlobalSecondaryIndexes" : [{
-          "IndexName" : "email-index",
+          "GlobalSecondaryIndexes" : [{
+            "IndexName" : "email-index",
+            "Projection": { "ProjectionType": "ALL" },
+            "KeySchema" : [{ "AttributeName" : "email", "KeyType" : "HASH"}],
+            "ProvisionedThroughput" : { "ReadCapacityUnits" : "1", "WriteCapacityUnits" : "1" }
+          }, {
+          "IndexName" : "api-key-hash-index",
           "Projection": { "ProjectionType": "ALL" },
-          "KeySchema" : [{ "AttributeName" : "email", "KeyType" : "HASH"}],
+          "KeySchema" : [{ "AttributeName" : "api-key-hash", "KeyType" : "HASH" }],
           "ProvisionedThroughput" : { "ReadCapacityUnits" : "1", "WriteCapacityUnits" : "1" }
-        }, {
-        "IndexName" : "api-key-hash-index",
-        "Projection": { "ProjectionType": "ALL" },
-        "KeySchema" : [{ "AttributeName" : "api-key-hash", "KeyType" : "HASH" }],
-        "ProvisionedThroughput" : { "ReadCapacityUnits" : "1", "WriteCapacityUnits" : "1" }
         }, {
         "IndexName" : "password-reset-token-index",
         "Projection": { "ProjectionType": "ALL" },
@@ -675,7 +674,7 @@
           "Statement":[{
             "Sid": "Allow administration of the key",
             "Effect": "Allow",
-            "Principal": { "Ref": "ConsolePrivateManagementRole" },
+            "Principal": { "AWS": { "Fn::Join": ["", ["arn:aws:iam::", { "Ref" : "AWS::AccountId" }, ":root"]] } },
             "Action": [
               "kms:Create*",
               "kms:Describe*",
@@ -697,6 +696,18 @@
           "Sid": "Allow use of the key",
           "Effect": "Allow",
           "Principal": { "AWS": {"Fn::GetAtt": ["ConsolePrivateDynamoDBUser", "Arn"]} },
+          "Action": [
+            "kms:Encrypt",
+            "kms:Decrypt",
+            "kms:ReEncrypt*",
+            "kms:GenerateDataKey*",
+            "kms:DescribeKey"
+          ],
+          "Resource": "*"
+          }, {
+          "Sid": "Allow use of the key",
+          "Effect": "Allow",
+          "Principal": { "AWS": {"Fn::GetAtt": ["ConsolePrivateManagementRole", "Arn"]} },
           "Action": [
             "kms:Encrypt",
             "kms:Decrypt",

--- a/formation.json
+++ b/formation.json
@@ -165,6 +165,24 @@
         "UserName": { "Ref": "ConsolePrivateIntegrationsUser" }
       }
     },
+    "ConsolePrivateManagementRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "RoleName":
+        "AssumeRolePolicyDocument": {
+          "Version" : "2012-10-17",
+          "Statement": [ {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": [ "ec2.amazonaws.com" ]
+            },
+            "Action": [ "sts:AssumeRole" ]
+          } ]
+        },
+        "Path": "/",
+        "Policies": []
+      }
+    },
     "ConsolePrivateUsersDynamoDBTable" : {
       "Type" : "AWS::DynamoDB::Table",
       "Properties" : {

--- a/formation.json
+++ b/formation.json
@@ -81,21 +81,19 @@
               "Resource" : "*"
               }, {
               "Action": "s3:*",
-              "Resource": [
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:s3:::",
-                    {"Ref": "ConsolePrivateWorkflowBucket"}
-                  ]
-                ],
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:s3:::",
-                    {"Ref": "ConsolePrivateWorkflowBucket"},
-                    "/*"
-                  ]
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:s3:::",
+                  {"Ref": "ConsolePrivateWorkflowBucket"}
+                ]
+              ],
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:s3:::",
+                  {"Ref": "ConsolePrivateWorkflowBucket"},
+                  "/*"
                 ]
               ],
               "Effect": "Allow"


### PR DESCRIPTION
I still couldn't get it to create the kms key without specifying that root could manage the key.
This does work though