### PR TITLE
Remove SnoopEncryptionKey from CF Outputs

### DIFF
--- a/formation.json
+++ b/formation.json
@@ -58,9 +58,6 @@
     "SessionKey": {
       "Value": { "Fn::Base64": { "Ref": "AWS::StackId" } }
     },
-    "SnoopEncryptionKey": {
-      "Value": { "Fn::Base64": { "Ref": "AWS::StackId" } }
-    },
     "StripePublishableKey": {
       "Value": ""
     },


### PR DESCRIPTION
A random string should be used rather than the generated output.