### PR TITLE
Update console image - add aws cli

### DIFF
--- a/convox.yml
+++ b/convox.yml
@@ -31,7 +31,7 @@ services:
     health:
       interval: 30
       path: /check
-    image: enterprise.convox.com/console:2.1.15
+    image: enterprise.convox.com/console:2.1.16
     init: true
     internal: ${INTERNAL}
     port: https:3000
@@ -53,7 +53,7 @@ services:
       - TABLE_PREFIX
       - TUNNEL_HOST=
       - WORKER_QUEUE
-    image: enterprise.convox.com/console:2.1.15
+    image: enterprise.convox.com/console:2.1.16
     init: true
     scale:
       count: 1


### PR DESCRIPTION
New image is bundled with the `aws` cli as new rack updates will require it.