### PR TITLE
Change console version to 2.2.5

### DIFF
--- a/convox.yml
+++ b/convox.yml
@@ -31,7 +31,7 @@ services:
     health:
       interval: 30
       path: /check
-    image: enterprise.convox.com/console:2.2.3
+    image: enterprise.convox.com/console:2.2.5
     init: true
     internal: ${INTERNAL}
     port: https:3000
@@ -53,7 +53,7 @@ services:
       - TABLE_PREFIX
       - TUNNEL_HOST=
       - WORKER_QUEUE
-    image: enterprise.convox.com/console:2.2.3
+    image: enterprise.convox.com/console:2.2.5
     init: true
     scale:
       count: 1


### PR DESCRIPTION
Update console version to 2.2.5 to get the fix for GitLab tokens.