### PR TITLE
Revert "Bump console version to 2.2.10"

### DIFF
--- a/convox.yml
+++ b/convox.yml
@@ -32,7 +32,7 @@ services:
     health:
       interval: 30
       path: /check
-    image: enterprise.convox.com/console:2.2.10
+    image: enterprise.convox.com/console:2.2.9
     init: true
     internal: ${INTERNAL}
     port: https:3000
@@ -52,7 +52,7 @@ services:
       - RACK_KEY
       - RACK_SYNC_WORKER_QUEUE
       - TABLE_PREFIX
-    image: enterprise.convox.com/console:2.2.10
+    image: enterprise.convox.com/console:2.2.9
     init: true
     scale:
       count: 1
@@ -72,7 +72,7 @@ services:
       - TABLE_PREFIX
       - TUNNEL_HOST=
       - WORKER_QUEUE
-    image: enterprise.convox.com/console:2.2.10
+    image: enterprise.convox.com/console:2.2.9
     init: true
     scale:
       count: 1


### PR DESCRIPTION
Reverts convox/console-app#55

See: 

- https://github.com/convox/console/pull/281
- https://github.com/convox/enterprise/pull/52