### PR TITLE
console 3.0.28 updates

### DIFF
--- a/convox.yml
+++ b/convox.yml
@@ -28,14 +28,14 @@ services:
       - OAUTH_CALLBACK_HOST=${HOST}
       - CACHE_REDIS_ADDR=
       - API_CONCURRENCY=10000
-    image: enterprise.convox.com/console:3.0.27
+    image: enterprise.convox.com/console:3.0.28
     init: true
     scale:
       count: 1
       cpu: 128
       memory: 500
   console3:
-    image: enterprise.convox.com/console:3.0.27
+    image: enterprise.convox.com/console:3.0.28
     command: web
     domain: ${HOST}
     environment:


### PR DESCRIPTION
Update Console image to `3.0.28` 

- convox/stdsdk bump to v0.0.4 for WebSocket fix