### PR TITLE
console 3.0.29 updates

### DIFF
--- a/convox.yml
+++ b/convox.yml
@@ -28,14 +28,14 @@ services:
       - OAUTH_CALLBACK_HOST=${HOST}
       - CACHE_REDIS_ADDR=
       - API_CONCURRENCY=10000
-    image: enterprise.convox.com/console:3.0.28
+    image: enterprise.convox.com/console:3.0.29
     init: true
     scale:
       count: 1
       cpu: 128
       memory: 500
   console3:
-    image: enterprise.convox.com/console:3.0.28
+    image: enterprise.convox.com/console:3.0.29
     command: web
     domain: ${HOST}
     environment:


### PR DESCRIPTION
Update Console image to `3.0.29` 

- short circuit loggroup query when resource doesn't exist to mitigate orphaned looping queries.
- rack side fix in version `3.24.9`